### PR TITLE
chore: Update dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@xmpp/client": "^0.11.1",
-    "@xmpp/debug": "^0.11.0"
+    "@xmpp/client": "^0.13.1",
+    "@xmpp/debug": "^0.13.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.9.6",
-    "@babel/preset-env": "^7.9.6",
-    "babel-loader": "^8.1.0",
+    "@babel/core": "^7.23.2",
+    "@babel/preset-env": "^7.23.2",
+    "babel-loader": "^9.1.3",
     "babel-plugin-transform-react-jsx": "^6.24.1",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11"
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Updated using npm-check-updates --upgrade. Notably, the update fixes
a ERR_OSSL_EVP_UNSUPPORTED error throw with newer versions of npm/node.
