### PR TITLE
feat: add skipConferenceRequest config option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ No test suite. No linter configured.
 | `delay` | ms between participant joins |
 | `conferenceRequestTarget` | `"http"` or `"xmpp"` |
 | `disableJoinMuc` | skip MUC join (test without conference) |
+| `skipConferenceRequest` | join MUC without sending conference-request to jicofo |
 | `duration` | how long participants stay (seconds) |
 | `enableDebug` / `enableXmppLog` | verbose logging |
 

--- a/src/Participant.js
+++ b/src/Participant.js
@@ -24,10 +24,10 @@ export default class Participant extends EventEmitter {
     }
 
     async join() {
-        const { service, domain, room, muc, conferenceRequestTarget } = this._config;
+        const { service, domain, room, muc, conferenceRequestTarget, skipConferenceRequest } = this._config;
 
         try {
-            const url = this._getConferenceRequestUrl();
+            const url = skipConferenceRequest ? undefined : this._getConferenceRequestUrl();
             if (url) {
                 await this._sendConferenceRequestHttp(url);
             }
@@ -56,7 +56,7 @@ export default class Participant extends EventEmitter {
             xmpp.on('stanza', (stanza) => this.emit('stanza', stanza));
             xmpp.iqCallee.set('urn:xmpp:jingle:1', 'jingle', this._onJingle.bind(this));
 
-            if (!url) {
+            if (!url && !skipConferenceRequest) {
                 await this._sendConferenceRequestXmpp(conferenceRequestTarget);
             }
 


### PR DESCRIPTION
## Summary
- Adds `skipConferenceRequest` config flag — when set, a `Participant` joins its MUC without sending a conference-request (HTTP or XMPP) to jicofo.
- Useful for testing what happens when a client joins/attempts to create a room without going through jicofo (e.g. anonymous room-creation restrictions on the MUC component).